### PR TITLE
Corrige /api/impots/ping avec de mauvais credentials

### DIFF
--- a/api/impots/impots.controller.js
+++ b/api/impots/impots.controller.js
@@ -57,7 +57,7 @@ function ImpotController (options) {
     var numeroFiscal = options.numeroFiscal
     var referenceAvis = options.referenceAvis
     if (!numeroFiscal || !referenceAvis) {
-      return next(new StandardError('Les paramètres numeroFiscal et referenceAvis doivent être fournis dans la requête.', {code: 400, scope: 'dgfip'}))
+      return next(new StandardError('Les paramètres numeroFiscal et referenceAvis doivent être fournis dans la requête.', {code: 400}))
     } else {
       svair(options.svairHost)(numeroFiscal, referenceAvis, function (err) {
         sendDataFromSvair(err, 'pong', next, res)


### PR DESCRIPTION
Actuellement lorsqu'on requête /api/impots/ping avec une mauvaise configuration de numeroFiscal/referenceAvis (provenant de l'environnement une erreur survient car l'erreur retournée est filtrée par scope d'un consumer inexistant.

La modification laisse passer les erreurs provenant de /api/impots/ping sans passer par la vérification de scope.